### PR TITLE
Replace deprecated circlebuf with deque

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PLUGIN_NAME: recursion-effect
-  OBS_VERSION: 28.0.0-rc1
+  OBS_VERSION: 30.2.3
 jobs:
   macos:
     name: macOS


### PR DESCRIPTION
libobs/util/circlebuf.h was deprecated in obsproject/obs-studio@a4b8e1a6. Without digging in too deeply, based on obsproject/obs-studio@9f306fa8 it looks like deque.h works as a drop-in replacement.

Fixes #5 